### PR TITLE
Use source_digest in coveralls json

### DIFF
--- a/src/Bundle/CoverallsBundle/Entity/SourceFile.php
+++ b/src/Bundle/CoverallsBundle/Entity/SourceFile.php
@@ -22,6 +22,13 @@ class SourceFile extends Coveralls
      * @var string
      */
     protected $source;
+    
+    /**
+     * Source digest of the content.
+     *
+     * @var string
+     */
+    protected $sourceDigest;
 
     /**
      * Coverage data of the source file.
@@ -63,6 +70,7 @@ class SourceFile extends Coveralls
         $this->path = $path;
         $this->name = $name;
         $this->source = trim(file_get_contents($path));
+        $this->sourceDigest = md5($this->source);
 
         $lines = explode($eol, $this->source);
         $this->fileLines = count($lines);
@@ -78,7 +86,7 @@ class SourceFile extends Coveralls
     {
         return [
             'name' => $this->name,
-            'source' => $this->source,
+            'source_digest' => $this->sourceDigest,
             'coverage' => $this->coverage,
         ];
     }


### PR DESCRIPTION
php-coveralls handles creating the json object which it sends to the coveralls api.
We would rather not send our direct source code to coveralls. It creates an 
unnecessarily large object as well. Instead, the api allows us to send an md5 digest
of the code.

Ref: https://docs.coveralls.io/api-reference

CC @BaseInfinity @davidrans 