### PR TITLE
Allow us to override the branch

### DIFF
--- a/src/Bundle/CoverallsBundle/Collector/GitInfoCollector.php
+++ b/src/Bundle/CoverallsBundle/Collector/GitInfoCollector.php
@@ -40,7 +40,7 @@ class GitInfoCollector
      */
     public function collect()
     {
-        $branch = $this->collectBranch();
+        $branch = getenv('OVERRIDE_BRANCH') ?: $this->collectBranch();
         $commit = $this->collectCommit();
         $remotes = $this->collectRemotes();
 


### PR DESCRIPTION
When we run ci, we checkout the branch and merge in master. This leaves us in a detached
state. This means that we aren't really on a branch anymore. On deploy, we need to set the
branch to master so that coveralls knows how to compare coverages. This allows us to
override the branch.

![image](https://user-images.githubusercontent.com/29667789/118864184-94707280-b894-11eb-8eb3-8b42d970397e.png)

qa_req 0 I don't think we will be able to qa this until https://github.com/iFixit/ifixit/pull/37673 goes out.