### PR TITLE
php-coveralls: Allow overriding the commit sha

### DIFF
--- a/src/Component/System/Git/GitCommand.php
+++ b/src/Component/System/Git/GitCommand.php
@@ -39,6 +39,9 @@ class GitCommand
      */
     public function getHeadCommit()
     {
+        if ($overrideCommit = getenv('OVERRIDE_COMMIT')) {
+            return $this->executor->execute("git show {$overrideCommit} --pretty=format:'%H%n%aN%n%ae%n%cN%n%ce%n%s' --no-patch");
+        }
         return $this->executor->execute("git log -1 --pretty=format:'%H%n%aN%n%ae%n%cN%n%ce%n%s'");
     }
 


### PR DESCRIPTION
In ci, we merge in master which puts us on a different commit sha which we just
throw away afterwords. If we just do `git log -1`, we get the commit information
of the throwaway merge commit.

Instead, let us override this with the 'correct' information of the HEAD of the 
actual branch.

qa_req 0 This will be tested on the ifixit/ifixit side.